### PR TITLE
Adding Get-NixLog

### DIFF
--- a/Get-NixLog.ps1
+++ b/Get-NixLog.ps1
@@ -2,15 +2,14 @@ function Get-NixLog
 {
     <#
     .Synopsis
-        Gets log information from journalctl
+        Gets log information from journalctl or syslog formatted logs.
     .Description
         Gets log via journalctl produced by the journald service which is standard on all distros that use systemd.
+        Unless the -LogFilePath parameter is used, then it defaults to regex of the Syslog format.
     .Example
-        Get-NigLog # returns all logs unfiltered
+        Get-NigLog # returns all logs unfiltered from journald
     .Example
         Get-NixLog | Where {$psitem }
-    .Link
-        Get-NixUptime
     #>
     [OutputType([Nullable], [string])]
     [Cmdletbinding(DefaultParameterSetName='Journalctl')]
@@ -22,28 +21,76 @@ function Get-NixLog
 
     # A Time based filter for logs before a date. Example timestamp is "2020-04-08 17:12:00"
     [Parameter(ParameterSetName='Journalctl',ValueFromPipelineByPropertyName)]
-    [Parameter(ParameterSetName='LogFile',ValueFromPipelineByPropertyName)]
     [string]
+    [alias('until')]
     $Before,
 
     # A Time based filter for logs after a date. Example timestamp is "2020-04-08 17:12:00"
     [Parameter(ParameterSetName='Journalctl',ValueFromPipelineByPropertyName)]
-    [Parameter(ParameterSetName='LogFile',ValueFromPipelineByPropertyName)]
     [string]
+    [alias('since')]
     $After,
+
+    # Explicitly require logs in UTC
+    [Parameter(ParameterSetName='Journalctl',ValueFromPipelineByPropertyName)]
+    [switch]
+    $UTC,
+
+    # Request only kernel logs like dmesg
+    [Parameter(ParameterSetName='Journalctl',ValueFromPipelineByPropertyName)]
+    [switch]
+    [alias('dmesg')]
+    $KernalOnly,
+
+    # Offset number of the boot logs to look at. 0 is current boot, -1 is previous, etc.
+    [Parameter(ParameterSetName='Journalctl',ValueFromPipelineByPropertyName)]
+    [int]
+    [alias('b')]
+    $Boot,
+
+    # Number of lines to show
+    [Parameter(ParameterSetName='Journalctl',ValueFromPipelineByPropertyName)]
+    [uint]
+    [alias('n')]
+    $LineNumber,
+
+    # The specific syslog identifier you are looking at filtering. Can provided multiple identifiers
+    [Parameter(ParameterSetName='Journalctl',ValueFromPipelineByPropertyName)]
+    [string[]]
+    $Identifier,
+
+    # The specific Systemd unit you are looking at filtering. Can provided multiple units
+    [Parameter(ParameterSetName='Journalctl',ValueFromPipelineByPropertyName)]
+    [string[]]
+    $Unit,
 
     # The priority of the logs you want to retrieve.
     # "emerg" (0), "alert" (1), "crit" (2), "err" (3), "warning" (4), "notice" (5), "info" (6), "debug" (7).
     [Parameter(ParameterSetName='Journalctl',ValueFromPipelineByPropertyName)]
-    [Parameter(ParameterSetName='LogFile',ValueFromPipelineByPropertyName)]
     [string[]]
     $Priority
     )
 
     process {
         if($LogFilePath) {
-            #some regex
-            #some file check
+            $LogFileContent = Get-Content -Path $LogFilePath
+
+            $LogFileContent |
+            & { process {
+                #Split the syslog file by date, hostname, process to the first :, and message
+                $null, $date, $hostname, $process, $message = $PSItem -split '(?<date>^\w.+:\d{2})\s(?<hostname>\w+)\s(?<process>.+?:)\s(?<message>.*)'
+                #Match a pid for the format [<number>] and assign it to the group process_pid
+                $process_pid = if($process -match '(?<process_pid>(?<=\[)(?>.+\d)(?=\]))' ){$matches.process_pid} else{$null}
+                #Match a process until a [ or :
+                $process_name = if($process -match '(?<process_name>^.+\w(?=\[|:))'){$matches.process_name}
+                [PSCustomObject][ordered]@{
+                    DATE = $date
+                    HOSTNAME = $hostname
+                    PROCESS = $process_name
+                    PID = $process_pid
+                    MESSAGE = $message
+                }
+            } }
         } else {
             # check that the system is using systemd
             if (-not (pidof systemd)) {
@@ -52,6 +99,12 @@ function Get-NixLog
             }
             $journalArgs = [System.Text.StringBuilder]::new()
             $null = $journalArgs.Append('-r -o json')
+            if($UTC){$null = $journalArgs.Append(" --utc ")}
+            if($KernalOnly){$null = $journalArgs.Append(" --dmesg ")}
+            if($Boot){$null = $journalArgs.Append(" -b $Boot ")}
+            if($LineNumber){$null = $journalArgs.Append(" -n $LineNumber ")}
+            if($Identifier){foreach($i in $Identifier){ $null = $journalArgs.Append(" -t $i ")}}
+            if($Unit){foreach($u in $Unit){ $null = $journalArgs.Append(" -u $u ")}}
             if($Before){$null = $journalArgs.Append(" -U `"$Before`"")}
             if($After){$null = $journalArgs.Append(" -S `"$After`"")}
             if($Priority)

--- a/Get-NixLog.ps1
+++ b/Get-NixLog.ps1
@@ -1,0 +1,83 @@
+function Get-NixLog
+{
+    <#
+    .Synopsis
+        Gets log information from journalctl
+    .Description
+        Gets log via journalctl produced by the journald service which is standard on all distros that use systemd.
+    .Example
+        Get-NigLog # returns all logs unfiltered
+    .Example
+        Get-NixLog | Where {$psitem }
+    .Link
+        Get-NixUptime
+    #>
+    [OutputType([Nullable], [string])]
+    [Cmdletbinding(DefaultParameterSetName='Journalctl')]
+    param(
+    # The path to the logfile read by.
+    [Parameter(ValueFromPipelineByPropertyName,ParameterSetName='LogFile')]
+    [System.IO.FileInfo]
+    $LogFilePath,
+
+    # A Time based filter for logs before a date. Example timestamp is "2020-04-08 17:12:00"
+    [Parameter(ParameterSetName='Journalctl',ValueFromPipelineByPropertyName)]
+    [Parameter(ParameterSetName='LogFile',ValueFromPipelineByPropertyName)]
+    [string]
+    $Before,
+
+    # A Time based filter for logs after a date. Example timestamp is "2020-04-08 17:12:00"
+    [Parameter(ParameterSetName='Journalctl',ValueFromPipelineByPropertyName)]
+    [Parameter(ParameterSetName='LogFile',ValueFromPipelineByPropertyName)]
+    [string]
+    $After,
+
+    # The priority of the logs you want to retrieve.
+    # "emerg" (0), "alert" (1), "crit" (2), "err" (3), "warning" (4), "notice" (5), "info" (6), "debug" (7).
+    [Parameter(ParameterSetName='Journalctl',ValueFromPipelineByPropertyName)]
+    [Parameter(ParameterSetName='LogFile',ValueFromPipelineByPropertyName)]
+    [string[]]
+    $Priority
+    )
+
+    process {
+        if($LogFilePath) {
+            #some regex
+            #some file check
+        } else {
+            # check that the system is using systemd
+            if (-not (pidof systemd)) {
+                Write-Error "Systemd not detected must use -LogFilePath" -ErrorId File.Missing
+                return
+            }
+            $journalArgs = [System.Text.StringBuilder]::new()
+            $null = $journalArgs.Append('-r -o json')
+            if($Before){$null = $journalArgs.Append(" -U `"$Before`"")}
+            if($After){$null = $journalArgs.Append(" -S `"$After`"")}
+            if($Priority)
+            {
+                if ($Priority.Count -gt 1)
+                {
+                    $null = $journalArgs.Append(" -p $($priority[0])..$($priority[-1])")
+                } else
+                {
+                    $null = $journalArgs.Append(" -p $Priority")
+                }
+            }
+            # Invoking journalctl with arguements from parameters.
+            Invoke-Expression "journalctl $($journalArgs.tostring())" | convertfrom-json |
+            & {
+                process {
+                    $journalcltLogs = [Ordered]@{PSTypeName='PowerNix.Logs'} # create a dictionary to hold logs.
+                    foreach($v in $psitem.psobject.properties) {
+                        $name = $($v.name -replace '^_{1,2}') # Removing all leading underscores
+                        $value = $v.value
+                        $journalcltLogs[$name] = $value
+                    }
+                    [PSCustomObject]$journalcltLogs
+                }
+            }
+        }
+    }
+}
+

--- a/Get-NixLog.ps1
+++ b/Get-NixLog.ps1
@@ -5,11 +5,59 @@ function Get-NixLog
         Gets log information from journalctl or syslog formatted logs.
     .Description
         Gets log via journalctl produced by the journald service which is standard on all distros that use systemd.
-        Unless the -LogFilePath parameter is used, then it defaults to regex of the Syslog format.
+        If the -LogFilePath parameter is used then the command uses regex to parse in the Syslog format.
+        Otherwise
     .Example
-        Get-NigLog # returns all logs unfiltered from journald
+        # returns all logs unfiltered from journald
+        Get-NigLog
+
+        CURSOR                    : s=1032b59ef7f247819e0500ebe21424d3;i=19ac95;b=cab0af3b917244288fe2a15fc3b01
+                                    a42;m=1767c381e6c;t=5c65195d4a866;x=2e08686703b082cb
+        REALTIME_TIMESTAMP        : 1625428591945830
+        MONOTONIC_TIMESTAMP       : 1608401821292
+        BOOT_ID                   : <someBootID>
+        MACHINE_ID                : <someGuid>
+        HOSTNAME                  : ubuntu
+        SELINUX_CONTEXT           : unconfined
+
+        SYSTEMD_SLICE             : system.slice
+        SYSLOG_FACILITY           : 3
+        TRANSPORT                 : journal
+        PRIORITY                  : 4
+        CODE_FILE                 : ../src/resolve/resolved-dns-transaction.c
+        CODE_LINE                 : 1047
+        CODE_FUNC                 : dns_transaction_process_reply
+        SYSLOG_IDENTIFIER         : systemd-resolved
+        MESSAGE                   : Server returned error NXDOMAIN, mitigating potential DNS violation
+                                    DVE-2018-0001, retrying transaction with reduced feature level UDP.
+        PID                       : 899
+        UID                       : 101
+        GID                       : 103
+        COMM                      : systemd-resolve
+        EXE                       : /lib/systemd/systemd-resolved
+        CMDLINE                   : /lib/systemd/systemd-resolved
+        CAP_EFFECTIVE             : 0
+        SYSTEMD_CGROUP            : /system.slice/systemd-resolved.service
+        SYSTEMD_UNIT              : systemd-resolved.service
+        SYSTEMD_INVOCATION_ID     : <someSystemD_ID>
+        SOURCE_REALTIME_TIMESTAMP : 1625428591945762
+
     .Example
-        Get-NixLog | Where {$psitem }
+        # Returns logs from the /var/log/syslog in the following format
+        Get-NixLog -LogFilePath /var/log/syslog
+
+        DATE     : Jun  20 19:56:14
+        HOSTNAME : ubuntu
+        PROCESS  : powershell
+        PID      : 16195
+        MESSAGE  : {(7.1.3:1:80)
+                [Perftrack_ConsoleStartupStart:PowershellConsoleStartup.WinStart.Informational] PowerShell
+                console is starting up, }
+    .Example
+        # Uses native journalctl filtering to limit logs to a specifc time and priority
+        # Like other PowerShell commands filtering on the cmdlet is faster than filtering later in the pipeline
+        Get-NixLog -After "2021-06-21 00:00:00" -Priority err,warning | select -first 10
+
     #>
     [OutputType([Nullable], [string])]
     [Cmdletbinding(DefaultParameterSetName='Journalctl')]

--- a/PowerNix.tests.ps1
+++ b/PowerNix.tests.ps1
@@ -42,7 +42,7 @@ Aug 24 00:06:07 ubuntu systemd[1]: Started Network Manager.
             $FileLogs = Get-NixLog -LogFilePath '/tmp/test-syslog'
         }
         AfterAll{
-            Remote-Item -Path '/tmp/test-syslog' -Force
+            Remove-Item -Path '/tmp/test-syslog' -Force
         }
         It 'Should get logs from /var/log/test-syslog' {
             $FileLogs | Should -not -be $null

--- a/PowerNix.tests.ps1
+++ b/PowerNix.tests.ps1
@@ -39,9 +39,9 @@ describe PowerNix {
         It 'Should get logs from /var/log/syslog' {
             $FileLogs | Should -not -be $null
         }
-        It 'Should have a syslog for PowerShell' {
-            $PowerShellLog = $FileLogs | Where-Object { $psitem.Process -ieq 'Powershell' } | Select-Object -First 1
-            $PowerShellLog | Should -not -be $null
+        It 'Should have a message from syslog' {
+            $Message = $FileLogs | Select-Object -First 1 -Property Message
+            $Message | Should -not -be $null
         }
         It 'Should get Kernel Logs' {
             $KernelLogs = Get-NixLog -KernalOnly -LineNumber 1

--- a/PowerNix.tests.ps1
+++ b/PowerNix.tests.ps1
@@ -35,11 +35,6 @@ describe PowerNix {
     context Logs {
         BeforeAll  {
             $FileLogs = Get-NixLog -LogFilePath /var/log/syslog
-            $KernelLogs = Get-NixLog -KernalOnly -LineNumber 1
-            $JournalctlLogs = Get-NixLog -Identifier powershell -LineNumber 1 -After "2021-06-21 11:00:00"
-            mock pidof {
-                return $true
-            }
         }
         It 'Should get logs from /var/log/syslog' {
             $FileLogs | Should -not -be $null
@@ -49,11 +44,13 @@ describe PowerNix {
             $PowerShellLog | Should -not -be $null
         }
         It 'Should get Kernel Logs' {
+            $KernelLogs = Get-NixLog -KernalOnly -LineNumber 1
             $KernelLogs.SYSLOG_IDENTIFIER | Should -Be 'kernel'
-        }
+        } -skip #because "systemd not present in container"
         It 'Should get a journald log for PowerShell' {
+            $JournalctlLogs = Get-NixLog -Identifier powershell -LineNumber 1 -After "2021-06-21 11:00:00"
             $JournalctlLogs.SYSLOG_IDENTIFIER | Should -be 'powershell'
-        }
+        } -skip #because "systemd not present in container"
     }
     it 'Can Get Uptimes' {
         $uptime = Get-NixUptime

--- a/PowerNix.tests.ps1
+++ b/PowerNix.tests.ps1
@@ -36,7 +36,10 @@ describe PowerNix {
         BeforeAll  {
             $FileLogs = Get-NixLog -LogFilePath /var/log/syslog
             $KernelLogs = Get-NixLog -KernalOnly -LineNumber 1
-            $JournalctlLogs = Get-NixLog -Unit PowerShell -LineNumber 1 -After "2021-06-21 11:00:00"
+            $JournalctlLogs = Get-NixLog -Identifier powershell -LineNumber 1 -After "2021-06-21 11:00:00"
+            mock pidof {
+                return $true
+            }
         }
         It 'Should get logs from /var/log/syslog' {
             $FileLogs | Should -not -be $null

--- a/PowerNix.tests.ps1
+++ b/PowerNix.tests.ps1
@@ -34,7 +34,7 @@ describe PowerNix {
 
     context Logs {
         BeforeAll  {
-            $FileLogs = Get-NixLog -LogFilePath /var/log/syslog
+            $FileLogs = Get-NixLog -LogFilePath '/var/log/syslog'
         }
         It 'Should get logs from /var/log/syslog' {
             $FileLogs | Should -not -be $null

--- a/PowerNix.tests.ps1
+++ b/PowerNix.tests.ps1
@@ -35,7 +35,7 @@ describe PowerNix {
     context Logs {
         BeforeAll  {
             $FileLogs = Get-NixLog -LogFilePath /var/log/syslog
-            $KernelLogs = Get-NixLog -KernelOnly -LineNumber 1
+            $KernelLogs = Get-NixLog -KernalOnly -LineNumber 1
             $JournalctlLogs = Get-NixLog -Unit PowerShell -LineNumber 1 -After "2021-06-21 11:00:00"
         }
         It 'Should get logs from /var/log/syslog' {

--- a/PowerNix.tests.ps1
+++ b/PowerNix.tests.ps1
@@ -34,9 +34,17 @@ describe PowerNix {
 
     context Logs {
         BeforeAll  {
-            $FileLogs = Get-NixLog -LogFilePath '/var/log/syslog'
+@'
+Aug 24 00:06:07 ubuntu rsyslogd: [origin software="rsyslogd" swVersion="8.2001.0" x-pid="699" x-info="https://www.rsyslog.com"] rsyslogd was HUPed
+Aug 24 00:06:07 ubuntu NetworkManager[690]: <info>  [1629763567.4088] NetworkManager (version 1.22.10) is starting... (for the first time)
+Aug 24 00:06:07 ubuntu systemd[1]: Started Network Manager.
+'@ | Set-Content '/tmp/test-syslog'
+            $FileLogs = Get-NixLog -LogFilePath '/tmp/test-syslog'
         }
-        It 'Should get logs from /var/log/syslog' {
+        AfterAll{
+            Remote-Item -Path '/tmp/test-syslog' -Force
+        }
+        It 'Should get logs from /var/log/test-syslog' {
             $FileLogs | Should -not -be $null
         }
         It 'Should have a message from syslog' {


### PR DESCRIPTION
This provides the requested function from issue #7 

It has two parameter sets:

1.  Using a log file where it assumes the standard Syslog format of (Date,Hostname,Process, Message)
2.  Using filtering parameters to return logs from the journalctl command.

The Default execution uses journalctl. 