### PR TITLE
Add check for the datetime parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.0.6] - 2021-09-07
+
+- Add Get-NixComputer and Get-NixDistro by @alaurie (PR #12)
+- Fix Datetime parsing (Issue #14)
+
 ## [0.0.5] - 2021-08-31
 
 - Fix hostname regex (Issue #11)

--- a/Get-NixComputer.ps1
+++ b/Get-NixComputer.ps1
@@ -5,9 +5,9 @@ function Get-NixComputer {
     .Description
         Gets the kernel info from the current Linux machine using the hostnamectl utility.
     .Example
-        Get-NixKernel # Get the current kernel
+        Get-NixComputer # Get the current kernel
     .Link
-        
+
     #>
     param(
     )
@@ -20,7 +20,7 @@ function Get-NixComputer {
                 $key, $value = $line.split(': ')
                 $key = $key -replace '\s'
                 $computerInfo[$key] = $value -replace '^"' -replace '"$'
-            }    
+            }
             [PSCustomObject]$computerInfo
         } catch {
             Write-Error 'Failed to run hostnamectl.'

--- a/Get-NixLog.ps1
+++ b/Get-NixLog.ps1
@@ -147,9 +147,11 @@ function Get-NixLog
                         $process_pid = if($process -match '(?<process_pid>(?<=\[)(?>.+\d)(?=\]))' ){$matches.process_pid -as [int]} else{$null}
                         #Match a process until a [ or :
                         $process_name = if($process -match '(?<process_name>^.+\w(?=\[|:))'){$matches.process_name}
+                        # Single digit days of the month have a leading space instead of a zero
+                        $date_parse = if($date -match '\s{2}\d'){'MMM  d HH:mm:ss'} else { 'MMM dd HH:mm:ss' }
                         [PSCustomObject][ordered]@{
                             PsTypeName = "PowerNix.Log.Syslog"
-                            DATE =  [datetime]::ParseExact($date, "MMM dd HH:mm:ss", [CultureInfo]::InvariantCulture)
+                            DATE =  [datetime]::ParseExact($date, $date_parse, [CultureInfo]::InvariantCulture)
                             HOSTNAME = $hostname
                             PROCESS = $process_name
                             PID = $process_pid

--- a/PowerNix.psd1
+++ b/PowerNix.psd1
@@ -1,5 +1,5 @@
 ﻿@{
-    ModuleVersion    = '0.0.5'
+    ModuleVersion    = '0.0.6'
     RootModule       = 'PowerNix.psm1'
     Guid             = '682b6083-8155-4787-8869-977effac7e8a'
     FormatsToProcess = 'PowerNix.format.ps1xml'

--- a/PowerNix.tests.ps1
+++ b/PowerNix.tests.ps1
@@ -40,6 +40,8 @@ Aug 24 00:06:07 ubuntu NetworkManager[690]: <info>  [1629763567.4088] NetworkMan
 Aug 24 00:06:07 ubuntu systemd[1]: Started Network Manager.
 Aug 24 00:00:01 linux-test systemd[1]: logrotate.service: Succeeded.
 Aug 24 00:00:01 linux_test systemd[1]: logrotate.service: Succeeded.
+Sep  7 15:57:24 ubuntu systemd[980]: Reached target Main User Target.
+Sep  7 15:57:24 ubuntu systemd[980]: Startup finished in 510ms.
 '@ | Set-Content '/tmp/test-syslog'
             $FileLogs = Get-NixLog -LogFilePath '/tmp/test-syslog'
         }

--- a/README.md
+++ b/README.md
@@ -21,15 +21,16 @@ The goal of PowerNix is to expose Linux functionality in a _good_ PowerShell mod
 
 To start off with, PowerNix has a few commands for getting system statistics and manipulating mounts.
 
--------------------
-|  Verb | Noun       |
-| ----: | :--------- |
-|   Get | -NixLog    |
-|       | -NixMemory |
-|       | -NixMount  |
-|       | -NixUptime |
-|       | -NixKernel |
-| Mount | -Nix       |
--------------------
+----------------------
+|  Verb | Noun        |
+| ----: | :-----------|
+|   Get | -NixLog     |
+|       | -NixMemory  |
+|       | -NixMount   |
+|       | -NixUptime  |
+|       | -NixDistro  |
+|       | -NixComputer|
+| Mount | -Nix        |
+----------------------
 
 #### Want to help out? [Contribute](contributing.md)


### PR DESCRIPTION
Found that the date for any day less than 10 was not parsing correctly in #14 

Adding an if statement to see if there is an extra space before the date before selecting the Exact Parse  